### PR TITLE
Add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,41 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and from version 4.0.0 this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+
+- Add `CHANGELOG.md` following [keep a changelog](https://keepachangelog.com/en/1.0.0/).
+
+## [3.0] – 2019-06-29
+
+### Added
+
+- Users can specify their own templates [#6](https://github.com/adoble/adr-j/issues/6)
+- Support of arbitrary languages for markdown files (e.g., [AsciiDoc](http://asciidoc.org/))
+
+## [2.1] – 2019-06-04
+
+### Changed
+
+- Switch to [picocli](https://picocli.info/) for command line parsing. See also [ADR-0006](https://github.com/adoble/adr-j/blob/master/doc/adr/0006-use-command-line-processing-package.md).
+
+## [2.0] – 2019-03-17
+
+### Added
+
+- Add support for unix (launc script, terminal support)
+
+## [1.0] – 2019-02-12
+
+Initial release
+
+[Unreleased]: https://github.com/adoble/adr-j/compare/v3.0...master
+[3.0]: https://github.com/adoble/adr-j/compare/v2.1...v3.0
+[2.1]: https://github.com/adoble/adr-j/compare/v2.0...v2.1
+[2.0]: https://github.com/adoble/adr-j/compare/v1.0...v2.0
+[1.0]: https://github.com/adoble/adr-j/releases/tag/v1.0


### PR DESCRIPTION
This adds a CHANGELOG following the format of http://keepachangelog.com/. The source of the items stems from https://github.com/adoble/adr-j/releases.

I propose to use [Semantic Versioning](https://semver.org/) from release 4.0.0 onwards.