### PR TITLE
Minor fixes

### DIFF
--- a/doc/example_templates/madr.md
+++ b/doc/example_templates/madr.md
@@ -1,8 +1,7 @@
 # {{name}}
 
 * Status: {{status}}
-Supersedes: [ADR {{{superseded.id}}}]({{{superseded.file}}})
-
+* Supersedes: [ADR {{{superseded.id}}}]({{{superseded.file}}})
 * Deciders: [list everyone involved in the decision] <!-- optional -->
 * Date: {{date}}
 
@@ -14,60 +13,61 @@ Technical Story: [description | ticket/issue URL] <!-- optional -->
 
 ## Decision Drivers <!-- optional -->
 
-* [driver 1, e.g., a force, facing concern, ...]
-* [driver 2, e.g., a force, facing concern, ...]
-* ... <!-- numbers of drivers can vary -->
+* [driver 1, e.g., a force, facing concern, …]
+* [driver 2, e.g., a force, facing concern, …]
+* … <!-- numbers of drivers can vary -->
 
 ## Considered Options
 
 * [option 1]
 * [option 2]
 * [option 3]
-* ... <!-- numbers of options can vary -->
+* … <!-- numbers of options can vary -->
 
 ## Decision Outcome
 
-Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | ... | comes out best (see below)].
+Chosen option: "[option 1]", because [justification. e.g., only option, which meets k.o. criterion decision driver | which resolves force force | … | comes out best (see below)].
 
 ### Positive Consequences <!-- optional -->
 
-* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, ...]
-* ...
+* [e.g., improvement of quality attribute satisfaction, follow-up decisions required, …]
+* …
 
 ### Negative Consequences <!-- optional -->
 
-* [e.g., compromising quality attribute, follow-up decisions required, ...]
-* ...
+* [e.g., compromising quality attribute, follow-up decisions required, …]
+* …
 
 ## Pros and Cons of the Options <!-- optional -->
 
 ### [option 1]
 
-[example | description | pointer to more information | ...] <!-- optional -->
+[example | description | pointer to more information | …] <!-- optional -->
 
 * Good, because [argument a]
 * Good, because [argument b]
 * Bad, because [argument c]
-* ... <!-- numbers of pros and cons can vary -->
+* … <!-- numbers of pros and cons can vary -->
 
 ### [option 2]
 
-[example | description | pointer to more information | ...] <!-- optional -->
+[example | description | pointer to more information | …] <!-- optional -->
 
 * Good, because [argument a]
 * Good, because [argument b]
 * Bad, because [argument c]
-* ... <!-- numbers of pros and cons can vary -->
+* … <!-- numbers of pros and cons can vary -->
 
 ### [option 3]
 
-[example | description | pointer to more information | ...] <!-- optional -->
+[example | description | pointer to more information | …] <!-- optional -->
 
 * Good, because [argument a]
 * Good, because [argument b]
 * Bad, because [argument c]
-* ... <!-- numbers of pros and cons can vary -->
+* … <!-- numbers of pros and cons can vary -->
 
 ## Links <!-- optional -->
 
 * {{{link.comment}}} [ADR {{{link.id}}}]({{{link.file}}})
+* … <!-- numbers of links can vary -->

--- a/doc/example_templates/madr_initial.md
+++ b/doc/example_templates/madr_initial.md
@@ -7,8 +7,9 @@
 ## Context and Problem Statement
 
 Decisions that might have an impact on the architecture are architectural decisions. It should be as easy as possible to:
-  1.  Write down the decisions
-  2.  Version the decisions
+
+ 1. Write down the decisions
+ 2. Version the decisions
 
 ## Decision Drivers
 
@@ -18,13 +19,14 @@ Decisions that might have an impact on the architecture are architectural decisi
 
 ## Considered Options
 
-* Write the architecture decisions in a document.
-* Write each architecture decision in a seperate file that can be versioned, i.e. as a lightweight Architecture Decision Record (ADR) and manually administer it.
+* Collect the architecture decisions in a single document.
+* Collect each architecture decision in a separate file that can be versioned, i.e. as a lightweight Architecture Decision Record (ADR) and manually administer it.
 * Use a tool to support the creation and administration of ADRs.
 
 ## Decision Outcome
 
-Chosen option:  
- 1. Use the [MADR](https://github.com/adr/madr/blob/master/docs/adr/0000-use-markdown-architectural-decision-records.md) format to document the architecture decisions succinctly
- 2. Write each architecture decision in a seperate file that can be versioned, i.e. as a lightweight Architeture Decision Record (ADR)
- 3. Use the  [adr-j](https://github.com/adoble/adr-j) tool to write and administer lightweight ADRs
+Chosen option: "Collect each architecture decision in a separate file".
+
+1. Use the [MADR](https://adr.github.io/madr/) format to document the architecture decisions succinctly
+2. Write each architecture decision in a separate file that can be versioned, i.e. as a lightweight Architecture Decision Record (ADR)
+3. Use the  [adr-j](https://github.com/adoble/adr-j) tool to write and administer lightweight ADRs

--- a/src/main/java/org/doble/commands/CommandNew.java
+++ b/src/main/java/org/doble/commands/CommandNew.java
@@ -120,14 +120,8 @@ public class CommandNew implements Callable<Integer> {
 	    } 
 	    		
 		// Create the ADR title from the arguments
-		StringBuilder sb = new StringBuilder();
-		for (String s : adrTitleParts)
-		{
-		    sb.append(s);
-		    sb.append(" ");
-		}
-		adrTitle = sb.toString().trim(); //Remove the last space
-		
+		adrTitle = adrTitleParts.stream().collect(Collectors.joining(" "));
+
 		// Build the record
 		Record record = new Record.Builder(docsPath)
 				.id(highestIndex() + 1)

--- a/src/test/java/org/doble/adr/CommandNewTest.java
+++ b/src/test/java/org/doble/adr/CommandNewTest.java
@@ -73,7 +73,7 @@ public class CommandNewTest {
 
 	@Test
 	public void testSimpleCommand() throws Exception {
-		String adrTitle = "This is a test achitecture decision";
+		String adrTitle = "This is a test architecture decision";
 
 		String[] args = TestUtilities.argify("new " + adrTitle);
 
@@ -81,7 +81,7 @@ public class CommandNewTest {
 		assertEquals(0, exitCode);
 
 		// Check if the ADR file has been created
-		assertTrue(Files.exists(fileSystem.getPath("/project/adr/doc/adr/0002-this-is-a-test-achitecture-decision.md"))); // ADR id is 2 as the first ADR was setup during init.
+		assertTrue(Files.exists(fileSystem.getPath("/project/adr/doc/adr/0002-this-is-a-test-architecture-decision.md"))); // ADR id is 2 as the first ADR was setup during init.
 	}
 
 	@Test


### PR DESCRIPTION
I updated the example template `madr.md` to be more close to MADR 2.1.2 (unicode symbol for ...)

Quick simplification of one code piece and fixed a typo.