### PR TITLE
Enable generation of native executables

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,21 +2,23 @@ version: 2
 jobs:
   build:
     docker:
-      - image: oracle/graalvm-ce:19.1.1
+      - image: oracle/graalvm-ce:latest
     environment:
+      GRADLE_OPTS: -Dorg.gradle.daemon=false
       JVM_OPTS: -Xmx3200m
       TERM: dumb
     steps:
       - checkout
       - restore_cache:
           keys:
-            - gradle-dependencies
-      - run: ./gradlew --no-daemon shadowJar
+            - gradle-dependencies-native
+      - run: ./gradlew shadowJar
+      - run: ./gradlew nativeImage
       - save_cache:
           paths:
             - ~/.gradle
-          key: gradle-dependencies
-      - run: gu install native-image
-      - run: cd build/libs && find . -name "*.jar" -exec native-image -jar \{\} \; && find . -name "*-fat" -exec mv \{\} adr \;
+          key: gradle-dependencies-native
       - store_artifacts:
           path: build/libs
+      - store_artifacts:
+          path: build/graal

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,45 @@
+os:
+  - linux
+  - windows
+
+dist: bionic
+addons:
+  apt:
+    packages:
+      - openjdk-8-jdk
+
+env:
+  global:
+    - GRADLE_OPTS=-Dorg.gradle.daemon=false
+    - TERM=dumb
+
+cache:
+  directories:
+    - /home/travis/.gradle/
+
+language: shell
+
+install:
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install jdk8 --version 8.0.221; fi
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then choco install windows-sdk-7.1 kb2519277; fi
+
+script:
+  # JAR is equal on Linux and Windows. So just build on Linux
+  - if [[ "$TRAVIS_OS_NAME" != "windows" ]]; then ./gradlew shadowJar; fi
+  # build native executable (windows: adr.exe, linux: adr)
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then JAVA_HOME="C:/Program Files/Java/jdk1.8.0_221" ./gradlew nativeImage; else ./gradlew nativeImage; fi
+  # have one build result folder --> build/libs
+  - cp build/graal/* build/libs
+  # dpl is required for uploading to gh-pages
+  - if [[ "$TRAVIS_OS_NAME" == "windows" ]]; then gem install bundler; gem install dpl --pre; fi
+
+deploy:
+  provider: pages
+  edge: true
+  github_token: $GITHUB_TOKEN  # Set in the settings page of your repository, as a secure variable
+  skip_cleanup: true
+  keep_history: true
+  verbose: true
+  local_dir: build/libs
+  on:
+    branch: enable-native-image-using-gradle-plugin

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id 'com.github.johnrengelman.shadow' version '4.0.2'
-    id "com.palantir.graal" version "0.4.0"
+    id "com.palantir.graal" version "0.6.0"
 }
 
 apply plugin: 'java'
@@ -8,12 +8,12 @@ apply plugin: 'application'
 
 graal {
     mainClass 'org.doble.adr.ADR'
-    graalVersion '19.1.1'
+    graalVersion '19.2.0.1'
     outputName 'adr'
 }
 
 group = 'org.doble'
-version = '0.0.1-SNAPSHOT'
+version = '3.1.0-SNAPSHOT'
 
 description = "adr-j"
 sourceCompatibility = 1.8


### PR DESCRIPTION
When executing `gradlew nativeImage`, one gets a binary for the current operating system. Refs #16.

I adopted the CircleCI build accordingly. I also started a TravisCI build, which generates an image for both linux and windows. Currently, the Windows image cannot be uploaded to a `gh-pages` branch due to an issue of the TravisCI-tool (refs https://github.com/travis-ci/dpl/issues/1105).

Minor fix: adopt the version number of adr-j in `build.gradle`.