### PR TITLE
Prefix editor environment variables with ADR_

### DIFF
--- a/doc/adr/0007-use-specific-environment-variables-for-editors.md
+++ b/doc/adr/0007-use-specific-environment-variables-for-editors.md
@@ -1,0 +1,31 @@
+# 7. Use specific environment variables for editors
+
+Date: Jan 29, 2021
+
+## Status
+
+Proposed
+
+
+## Context
+
+Users of the ADT tool might want to edit ADRs in the editor that's not the default system editor.
+
+ADT should introduce an additional `ADR_EDITOR` and `ADR_VISUAL` variables, so users may choose editors for ADRs.
+
+The enhancement proposal is in [project issues](https://github.com/adoble/adr-j/issues/4)
+
+## Decision
+
+We will read editor command from additional `ADR_EDITOR` and `ADR_VISUAL` variables.
+If custom variables are not set, we will fall back to reading `EDITOR` and `VISUAL` variables.
+
+We will extract editor command resolving code from ADR class and move it to dedicated class.
+That will improve testability and make further modifications easier.
+
+We will reflect adding new variables in the docs.
+
+## Consequences
+
+* The ADR tool behavior remains backward-compatible;
+* Editor command resolving will move out of launcher class;

--- a/doc/man/adr.md
+++ b/doc/man/adr.md
@@ -10,7 +10,7 @@
 
   [`init`](init.md)  Initialise the directory of architecture decision records.
 
-[`new`](new.md) Creates a new, numbered ADR.  
+[`new`](new.md) Creates a new, numbered ADR.
 
 [`list`](list.md) Lists the filenames of the currently created architecture decision records.
 
@@ -32,3 +32,5 @@ Exit Codes:
 
 # Environment Variables:
   `ADR_AUTHOR`   The author of the ADR
+  `ADR_EDITOR`   The editor to open ADRs
+  `ADR_VISUAL`   The editor to open ADRs. Ignored when `ADR_EDITOR` set

--- a/doc/man/adr.md
+++ b/doc/man/adr.md
@@ -10,7 +10,7 @@
 
   [`init`](init.md)  Initialise the directory of architecture decision records.
 
-[`new`](new.md) Creates a new, numbered ADR.
+[`new`](new.md) Creates a new, numbered ADR.  
 
 [`list`](list.md) Lists the filenames of the currently created architecture decision records.
 

--- a/doc/usage/INSTALL.md
+++ b/doc/usage/INSTALL.md
@@ -6,7 +6,7 @@
 2. Make sure you have gradle installed (https://gradle.org/).
 3. Run `gradlew releaseJar`. This should create a file `build/releases/adr-j.jar`.
 4. Set the environment variable `ADR_HOME` to the folder where you downloaded the source code. This should contain the `build` folder.
-5. Set the environment variable `EDITOR` or `VISUAL` to the location of the editor you what to use for editing the ADRs (e.g. Atom)
+5. Set the environment variable `ADR_EDITOR` or `ADR_VISUAL` to the location of the editor you what to use for editing the ADRs (e.g. Atom). If none of those variables set, ADR will use `EDITOR` and `VISUAL` variables.
 6. Add `%ADR_HOME%\launch-scripts` to the `PATH` environment variable
 
 You should now be able to type `adr` from the command line and see a response.

--- a/src/main/java/org/doble/adr/ADR.java
+++ b/src/main/java/org/doble/adr/ADR.java
@@ -26,7 +26,7 @@ import picocli.CommandLine.Model.UsageMessageSpec;
 
 /**
  * Java version of the adr tool at https://github.com/npryce/adr-tools.
- * 
+ *
  * @author adoble
  *
  */
@@ -34,34 +34,30 @@ public class ADR  {
 
 	final static public int MAX_ID_LENGTH = 4;
 	final static String ADR_DIR_NAME = ".adr";
-	
-	public static final Integer ERRORGENERAL =      1;  // General purpose error code
-	public static final Integer ERRORENVIRONMENT=   2;  // Environment variables not correctly set 
-	private Environment env;
-	
 
-      
+	public static final Integer ERRORGENERAL =      1;  // General purpose error code
+	public static final Integer ERRORENVIRONMENT=   2;  // Environment variables not correctly set
+	private Environment env;
+
+
+
 	/** ADR tool main entry
-	 * 
+	 *
 	 *
 	 * @param args  Command line arguments
-	 * 
+	 *
 	 */
 	public static void main(String[] args) {
 		int errorCode = 0;
-		
+
 		// Determine the editor from the system environment
-		String editorCommand = null;
-		editorCommand = System.getenv("EDITOR"); 
-		if (editorCommand == null) {
-			// Try VISUAL
-			editorCommand = System.getenv("VISUAL");
-		}
+		EditorCommandResolver editorCommandResolver = new EditorCommandResolver();
+		String editorCommand = editorCommandResolver.editorCommand();
 		// else leave as null to be picked up later
 		// TODO change this to an optional variable or an entry in the configuration file
-		
-			
-		// Set up the environment that the tool runs in with the 
+
+
+		// Set up the environment that the tool runs in with the
 		// default file system etc.
 		Environment mainEnv = new Environment.Builder(FileSystems.getDefault())
 				.out(System.out)
@@ -72,23 +68,23 @@ public class ADR  {
 				.editorRunner(new SystemEditorRunner())
 				.author(determineAuthor())
 				.build();
-		
-		errorCode = ADR.run(args, mainEnv);
-		
-		System.exit(errorCode);	
-		
 
-    
+		errorCode = ADR.run(args, mainEnv);
+
+		System.exit(errorCode);
+
+
+
 
 	}
-	
-	
+
+
 	 static public Integer run(String[] args, Environment env) {
 		Integer exitCode = 0;
-		
-		// Set up the command line processing and instantiate the main class using the default file system	
+
+		// Set up the command line processing and instantiate the main class using the default file system
 		// TODO use PrintWriters in the environment instead of PrintStreams
-		
+
 		CommandLine cmd = new CommandLine(new CommandADR(env))
 				.setOut(new PrintWriter(env.out))
 				.setErr(new PrintWriter(env.err));
@@ -96,42 +92,42 @@ public class ADR  {
 		installEnvironmentVariablesRender(cmd);
 
 		// If there are arguments then execute the subcommand
-		if (args.length == 0) 
-		{ 
-			cmd.usage(env.out); 
+		if (args.length == 0)
+		{
+			cmd.usage(env.out);
 		} else {
 			exitCode = cmd.execute(args);
-		}	
-		
+		}
+
 		return exitCode;
 
 	}
-	 
+
 	 public Environment getEnvironment() {
 		 return env;
 	 }
-	
 
-	 /** 
-	  * Get the root directory containing the .adr directory. 
+
+	 /**
+	  * Get the root directory containing the .adr directory.
 	  * @return Path The root directory
 	  * @throws ADRException Thrown if the root directory cannot be found
 	  */
 	 static public Path getRootPath(Environment env) throws ADRException  {
-		 // NOTE: This examines the directory for the root path each time, 
-		 // rather than storing the value. This is necessary to avoid 
-		 // ProviderMismatchExceptions later due to the filesystems that 
-		 // created the Path being different. 
+		 // NOTE: This examines the directory for the root path each time,
+		 // rather than storing the value. This is necessary to avoid
+		 // ProviderMismatchExceptions later due to the filesystems that
+		 // created the Path being different.
 
-		 // The directory containing the .adr directory, 
-		 // i.e. the root of the project 
-		 Optional<Path> rootPath = Optional.empty(); 
+		 // The directory containing the .adr directory,
+		 // i.e. the root of the project
+		 Optional<Path> rootPath = Optional.empty();
 
-		 // Find the root path, starting in the directory 
+		 // Find the root path, starting in the directory
 		 // where the ADR tool has been run.
 		 Path path = env.dir;
 
-		 Path adrFilePath; 
+		 Path adrFilePath;
 		 while (path != null) {
 			 adrFilePath = path.resolve(ADR.ADR_DIR_NAME);
 
@@ -139,7 +135,7 @@ public class ADR  {
 				 rootPath = Optional.of(path);
 				 break;
 			 } else {
-				 // Check the directory above 
+				 // Check the directory above
 				 path = path.getParent();
 			 }
 		 }
@@ -156,29 +152,29 @@ public class ADR  {
 
 
 	 }
-	 
+
 	 /**
-	  * Get the name of the file contaning the specified id. 
+	  * Get the name of the file contaning the specified id.
 	 * @param adrId The id of the ADR.
 	 * @param docsPath The path containing the ADRs.
 	 * @return The file name of the ADR
 	 */
-	static public String getADRFileName(int adrId, Path docsPath) { 
+	static public String getADRFileName(int adrId, Path docsPath) {
 		 String fileName;
 
-		 try { 
+		 try {
 			 Path[] paths = Files.list(docsPath).filter(ADRFilter.filter(adrId)).toArray(Path[]::new);
 
 
-			 if (paths.length == 1) { 
-				 fileName = paths[0].getFileName().toString(); 
-			 } 
-			 else { // Gracefully fail and return an empty string 
-				 fileName = ""; 
-			 } 
-		 } 
-		 catch (IOException e) { // Gracefully fail and return an empty string 
-			 fileName =	  ""; 
+			 if (paths.length == 1) {
+				 fileName = paths[0].getFileName().toString();
+			 }
+			 else { // Gracefully fail and return an empty string
+				 fileName = "";
+			 }
+		 }
+		 catch (IOException e) { // Gracefully fail and return an empty string
+			 fileName =	  "";
 		 }
 
 		 return fileName;

--- a/src/main/java/org/doble/adr/ADR.java
+++ b/src/main/java/org/doble/adr/ADR.java
@@ -213,6 +213,8 @@ public class ADR  {
 		EnvironmentVariablesRenderer() {
 			env = new HashMap<>();
 			env.put("ADR_AUTHOR", "The author of the ADR");
+			env.put("ADR_EDITOR", "The editor to use to edit ADRs");
+			env.put("ADR_VISUAL", "The editor to use to edit ADRs. Ignored, if ADR_EDITOR set");
 		}
 
 		@Override

--- a/src/main/java/org/doble/adr/ADR.java
+++ b/src/main/java/org/doble/adr/ADR.java
@@ -26,7 +26,7 @@ import picocli.CommandLine.Model.UsageMessageSpec;
 
 /**
  * Java version of the adr tool at https://github.com/npryce/adr-tools.
- *
+ * 
  * @author adoble
  *
  */
@@ -34,30 +34,30 @@ public class ADR  {
 
 	final static public int MAX_ID_LENGTH = 4;
 	final static String ADR_DIR_NAME = ".adr";
-
+	
 	public static final Integer ERRORGENERAL =      1;  // General purpose error code
-	public static final Integer ERRORENVIRONMENT=   2;  // Environment variables not correctly set
+	public static final Integer ERRORENVIRONMENT=   2;  // Environment variables not correctly set 
 	private Environment env;
+	
 
-
-
+      
 	/** ADR tool main entry
-	 *
+	 * 
 	 *
 	 * @param args  Command line arguments
-	 *
+	 * 
 	 */
 	public static void main(String[] args) {
 		int errorCode = 0;
-
+		
 		// Determine the editor from the system environment
 		EditorCommandResolver editorCommandResolver = new EditorCommandResolver();
 		String editorCommand = editorCommandResolver.editorCommand();
 		// else leave as null to be picked up later
 		// TODO change this to an optional variable or an entry in the configuration file
-
-
-		// Set up the environment that the tool runs in with the
+		
+			
+		// Set up the environment that the tool runs in with the 
 		// default file system etc.
 		Environment mainEnv = new Environment.Builder(FileSystems.getDefault())
 				.out(System.out)
@@ -68,23 +68,23 @@ public class ADR  {
 				.editorRunner(new SystemEditorRunner())
 				.author(determineAuthor())
 				.build();
-
+		
 		errorCode = ADR.run(args, mainEnv);
+		
+		System.exit(errorCode);	
+		
 
-		System.exit(errorCode);
-
-
-
+    
 
 	}
-
-
+	
+	
 	 static public Integer run(String[] args, Environment env) {
 		Integer exitCode = 0;
-
-		// Set up the command line processing and instantiate the main class using the default file system
+		
+		// Set up the command line processing and instantiate the main class using the default file system	
 		// TODO use PrintWriters in the environment instead of PrintStreams
-
+		
 		CommandLine cmd = new CommandLine(new CommandADR(env))
 				.setOut(new PrintWriter(env.out))
 				.setErr(new PrintWriter(env.err));
@@ -92,42 +92,42 @@ public class ADR  {
 		installEnvironmentVariablesRender(cmd);
 
 		// If there are arguments then execute the subcommand
-		if (args.length == 0)
-		{
-			cmd.usage(env.out);
+		if (args.length == 0) 
+		{ 
+			cmd.usage(env.out); 
 		} else {
 			exitCode = cmd.execute(args);
-		}
-
+		}	
+		
 		return exitCode;
 
 	}
-
+	 
 	 public Environment getEnvironment() {
 		 return env;
 	 }
+	
 
-
-	 /**
-	  * Get the root directory containing the .adr directory.
+	 /** 
+	  * Get the root directory containing the .adr directory. 
 	  * @return Path The root directory
 	  * @throws ADRException Thrown if the root directory cannot be found
 	  */
 	 static public Path getRootPath(Environment env) throws ADRException  {
-		 // NOTE: This examines the directory for the root path each time,
-		 // rather than storing the value. This is necessary to avoid
-		 // ProviderMismatchExceptions later due to the filesystems that
-		 // created the Path being different.
+		 // NOTE: This examines the directory for the root path each time, 
+		 // rather than storing the value. This is necessary to avoid 
+		 // ProviderMismatchExceptions later due to the filesystems that 
+		 // created the Path being different. 
 
-		 // The directory containing the .adr directory,
-		 // i.e. the root of the project
-		 Optional<Path> rootPath = Optional.empty();
+		 // The directory containing the .adr directory, 
+		 // i.e. the root of the project 
+		 Optional<Path> rootPath = Optional.empty(); 
 
-		 // Find the root path, starting in the directory
+		 // Find the root path, starting in the directory 
 		 // where the ADR tool has been run.
 		 Path path = env.dir;
 
-		 Path adrFilePath;
+		 Path adrFilePath; 
 		 while (path != null) {
 			 adrFilePath = path.resolve(ADR.ADR_DIR_NAME);
 
@@ -135,7 +135,7 @@ public class ADR  {
 				 rootPath = Optional.of(path);
 				 break;
 			 } else {
-				 // Check the directory above
+				 // Check the directory above 
 				 path = path.getParent();
 			 }
 		 }
@@ -152,29 +152,29 @@ public class ADR  {
 
 
 	 }
-
+	 
 	 /**
-	  * Get the name of the file contaning the specified id.
+	  * Get the name of the file contaning the specified id. 
 	 * @param adrId The id of the ADR.
 	 * @param docsPath The path containing the ADRs.
 	 * @return The file name of the ADR
 	 */
-	static public String getADRFileName(int adrId, Path docsPath) {
+	static public String getADRFileName(int adrId, Path docsPath) { 
 		 String fileName;
 
-		 try {
+		 try { 
 			 Path[] paths = Files.list(docsPath).filter(ADRFilter.filter(adrId)).toArray(Path[]::new);
 
 
-			 if (paths.length == 1) {
-				 fileName = paths[0].getFileName().toString();
-			 }
-			 else { // Gracefully fail and return an empty string
-				 fileName = "";
-			 }
-		 }
-		 catch (IOException e) { // Gracefully fail and return an empty string
-			 fileName =	  "";
+			 if (paths.length == 1) { 
+				 fileName = paths[0].getFileName().toString(); 
+			 } 
+			 else { // Gracefully fail and return an empty string 
+				 fileName = ""; 
+			 } 
+		 } 
+		 catch (IOException e) { // Gracefully fail and return an empty string 
+			 fileName =	  ""; 
 		 }
 
 		 return fileName;

--- a/src/main/java/org/doble/adr/EditorCommandResolver.java
+++ b/src/main/java/org/doble/adr/EditorCommandResolver.java
@@ -28,7 +28,7 @@ public class EditorCommandResolver {
 	 * @return the command if there is a set environment variable or null, if no variable set.
 	 */
 	public String editorCommand() {
-		return Stream.of("EDITOR", "VISUAL")
+		return Stream.of("ADR_EDITOR", "ADR_VISUAL", "EDITOR", "VISUAL")
 			.map(env::get)
 			.filter(Objects::nonNull)
 			.findFirst()

--- a/src/main/java/org/doble/adr/EditorCommandResolver.java
+++ b/src/main/java/org/doble/adr/EditorCommandResolver.java
@@ -1,0 +1,37 @@
+package org.doble.adr;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.stream.Stream;
+
+/**
+ * Extract editor command from the system environment.
+ */
+public class EditorCommandResolver {
+
+	private final Map<String, String> env;
+
+	public EditorCommandResolver(Map<String, String> env) {
+		this.env = env;
+	}
+
+	/**
+	 * Creates a default instance of resolver configured via actual environment variables.
+	 */
+	public EditorCommandResolver() {
+		this(System.getenv());
+	}
+
+	/**
+	 * Retrieve the command to launch editor.
+	 *
+	 * @return the command if there is a set environment variable or null, if no variable set.
+	 */
+	public String editorCommand() {
+		return Stream.of("EDITOR", "VISUAL")
+			.map(env::get)
+			.filter(Objects::nonNull)
+			.findFirst()
+			.orElse(null);
+	}
+}

--- a/src/main/java/org/doble/commands/CommandEdit.java
+++ b/src/main/java/org/doble/commands/CommandEdit.java
@@ -25,26 +25,26 @@ import picocli.CommandLine.ParentCommand;
          )
 public class CommandEdit implements Callable<Integer> {
 	@Parameters(paramLabel = "ADR_ID", description = "The identifier of the ADR to be edited.")
-	private int adrId;
+	private int adrId; 
 
 	@ParentCommand
 	private CommandADR commandADR;
-
+	
 	private Environment env;
 	private ADRProperties properties;
-
+	
 	@Override
 	public Integer call() throws Exception {
-		int exitCode = CommandLine.ExitCode.OK;
+		int exitCode = CommandLine.ExitCode.OK; 
 
 		env = commandADR.getEnvironment();
 
 		// Load the properties
 		properties = new ADRProperties(env);
-		properties.load();
+		properties.load(); 
 
 
-		// Determine where the .adr directory is stored, i.e. the root path.
+		// Determine where the .adr directory is stored, i.e. the root path. 
 		// If the directory has not been initialised, this will throw an exception
 		Path rootPath = ADR.getRootPath(env);
 
@@ -84,5 +84,5 @@ public class CommandEdit implements Callable<Integer> {
 	}
 
 
-
+	
 }

--- a/src/main/java/org/doble/commands/CommandEdit.java
+++ b/src/main/java/org/doble/commands/CommandEdit.java
@@ -25,26 +25,26 @@ import picocli.CommandLine.ParentCommand;
          )
 public class CommandEdit implements Callable<Integer> {
 	@Parameters(paramLabel = "ADR_ID", description = "The identifier of the ADR to be edited.")
-	private int adrId; 
+	private int adrId;
 
 	@ParentCommand
 	private CommandADR commandADR;
-	
+
 	private Environment env;
 	private ADRProperties properties;
-	
+
 	@Override
 	public Integer call() throws Exception {
-		int exitCode = CommandLine.ExitCode.OK; 
+		int exitCode = CommandLine.ExitCode.OK;
 
 		env = commandADR.getEnvironment();
 
 		// Load the properties
 		properties = new ADRProperties(env);
-		properties.load(); 
+		properties.load();
 
 
-		// Determine where the .adr directory is stored, i.e. the root path. 
+		// Determine where the .adr directory is stored, i.e. the root path.
 		// If the directory has not been initialised, this will throw an exception
 		Path rootPath = ADR.getRootPath(env);
 
@@ -54,7 +54,7 @@ public class CommandEdit implements Callable<Integer> {
 		// Check to see if the editor command has been set.
 		if (env.editorCommand == null) {
 			String msg = "ERROR: Editor for the ADR has not been found in the environment variables.\n"
-					+ "Have you set the environment variable EDITOR or VISUAL with the editor program you want to use?\n";
+					+ "Have you set the environment variable ADR_EDITOR, ADR_VISUAL, EDITOR or VISUAL with the editor program you want to use?\n";
 			env.err.println(msg);
 			exitCode =  CommandLine.ExitCode.SOFTWARE;
 		}
@@ -84,5 +84,5 @@ public class CommandEdit implements Callable<Integer> {
 	}
 
 
-	
+
 }

--- a/src/test/java/org/doble/adr/EditorCommandResolverTest.java
+++ b/src/test/java/org/doble/adr/EditorCommandResolverTest.java
@@ -52,4 +52,33 @@ class EditorCommandResolverTest {
 		assertEquals( "editor", editorCommand,
 			"The EDITOR variable has higher priority than VISUAL. The command must come from the EDITOR variable");
 	}
+
+	@Test
+	void preferPrefixedVisualToSystemEditors() {
+		Map<String, String> env = new HashMap<>();
+		env.put("VISUAL", "visual");
+		env.put("EDITOR", "editor");
+		env.put("ADR_VISUAL", "adr-visual");
+		EditorCommandResolver resolver = new EditorCommandResolver(env);
+
+		String editorCommand = resolver.editorCommand();
+
+		assertEquals( "adr-visual", editorCommand,
+			"The ADR-prefixed variable has higher priority than system variables");
+	}
+
+	@Test
+	void preferPrefixedEditorToAllOtherEditors() {
+		Map<String, String> env = new HashMap<>();
+		env.put("VISUAL", "visual");
+		env.put("ADR_EDITOR", "adr-editor");
+		env.put("EDITOR", "editor");
+		env.put("ADR_VISUAL", "adr-visual");
+		EditorCommandResolver resolver = new EditorCommandResolver(env);
+
+		String editorCommand = resolver.editorCommand();
+
+		assertEquals( "adr-editor", editorCommand,
+			"The ADR_EDITOR variable has highest priority");
+	}
 }

--- a/src/test/java/org/doble/adr/EditorCommandResolverTest.java
+++ b/src/test/java/org/doble/adr/EditorCommandResolverTest.java
@@ -1,0 +1,55 @@
+package org.doble.adr;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class EditorCommandResolverTest {
+
+	@Test
+	void editorCommandIsNullWhenNoVariablesSet() {
+		EditorCommandResolver resolver = new EditorCommandResolver(new HashMap<>());
+
+		String editorCommand = resolver.editorCommand();
+
+		assertNull(editorCommand, "no variables set so the editor command must be null");
+	}
+
+	@Test
+	void extractEditorCommandFromEditorVariable() {
+		Map<String, String> env = new HashMap<>();
+		env.put("EDITOR", "editor");
+		EditorCommandResolver resolver = new EditorCommandResolver(env);
+
+		String editorCommand = resolver.editorCommand();
+
+		assertEquals( "editor", editorCommand, "the command must be extracted from EDITOR variable");
+	}
+
+	@Test
+	void extractEditorCommandFromVisualVariable() {
+		Map<String, String> env = new HashMap<>();
+		env.put("VISUAL", "visual");
+		EditorCommandResolver resolver = new EditorCommandResolver(env);
+
+		String editorCommand = resolver.editorCommand();
+
+		assertEquals( "visual", editorCommand, "the command must be extracted from VISUAL variable");
+	}
+
+	@Test
+	void preferValueInEditorVariableOverVisualVariable() {
+		Map<String, String> env = new HashMap<>();
+		env.put("VISUAL", "visual");
+		env.put("EDITOR", "editor");
+		EditorCommandResolver resolver = new EditorCommandResolver(env);
+
+		String editorCommand = resolver.editorCommand();
+
+		assertEquals( "editor", editorCommand,
+			"The EDITOR variable has higher priority than VISUAL. The command must come from the EDITOR variable");
+	}
+}


### PR DESCRIPTION
Support the `ADR_EDITOR` and `ADR_VISUAL` environment variables to configure an editor.
New variables have precedence over the standard UNIX `EDITOR` and `VISUAL`. 
Old variables are still used, so the behavior should remain backward-compatible for existing users. 

fixes: #4 
