### PR TITLE
Make compatible starting at Java 1.8

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,9 @@ graal {
 }
 
 java {
-    sourceCompatibility = JavaVersion.VERSION_21
-    targetCompatibility = JavaVersion.VERSION_21 
-    mainClassName =   "org.doble.adr.ADR"  
+    sourceCompatibility = JavaVersion.VERSION_1_8
+    targetCompatibility = JavaVersion.VERSION_1_8
+    mainClassName =   "org.doble.adr.ADR"
 }
 
 group = 'org.doble'


### PR DESCRIPTION
Hi there,

We are using this in a project at work.

One thing that I missed was to be able to run it on older Java versions. We do use Java 17

So I've tried changing the build.gradle, set it to JAVA_1_8, compiled it using gradlew and java 21.

`./gradlew releaseJar`

So I did changed to java 1.8, I do use [sdkman](https://sdkman.io/) to menage multiple java versions.

```shell
$ sdk use java 8.0.412-tem
Using java version 8.0.412-tem in this shell.
$ java -version
openjdk version "1.8.0_412"
OpenJDK Runtime Environment (Temurin)(build 1.8.0_412-b08)
OpenJDK 64-Bit Server VM (Temurin)(build 25.412-b08, mixed mode)
$  java -jar build/releases/adr-j.jar list
0001-record-architecture-decisions.md
0005-help-comments.md
0008-use-java-lts-versions.md
0006-use-command-line-processing-package.md
0004-markdown-format.md
0007-use-specific-environment-variables-for-editors.md
0002-implement-as-Java.md
0009-plain-text-format.md
0003-single-command-with-subcommands.md
```

That's it, I was able to use it with Java 1.8.

Other than it later I may take some time to make list sub-command to list adr sorted.
Also thought about having it as a gradle plugin. 
Maybe in future.

