### PR TITLE
Set release option of compileJava to Java 11

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,6 +35,12 @@ application {
     mainClass = "org.doble.adr.ADR"
 }
 
+tasks.named<JavaCompile>("compileJava") {
+    options.apply {
+        release = 11
+    }
+}
+
 tasks.withType<AbstractArchiveTask>().configureEach {
     isPreserveFileTimestamps = false
     isReproducibleFileOrder = true


### PR DESCRIPTION
We could target release 11 due to one usage of Java 9 API:

https://docs.oracle.com/javase/9/docs/api/java/util/Objects.html#requireNonNullElse-T-T-

```
<redacted>/adr-j/src/main/java/org/doble/commands/CommandConfig.java:13: error: cannot find symbol
import static java.util.Objects.requireNonNullElse;
^
  symbol:   static requireNonNullElse
  location: class Objects
<redacted>/adr-j/src/main/java/org/doble/commands/CommandConfig.java:83: error: cannot find symbol
                authorEmail = requireNonNullElse(authorEmail, "").trim();
                              ^
  symbol:   method requireNonNullElse(String,String)
  location: class CommandConfig
2 errors
```

if we replace the `requireNonNullElse` call we could lower it to Java 8.

Java 9-10 were non-LTS releases, so it makes no sense to target them.

---

Using Java 21 with release 8 will output the following warning though:

```
warning: [options] source value 8 is obsolete and will be removed in a future release
```

---


```shell
$ gr releaseJar
$ javap \
  -verbose \
  -classpath \
  build/releases/adr-j.jar \
  $(
    jar -tf build/releases/adr-j.jar | \
    grep '\.class$' | \
    grep -E --invert-match '(module|package)-info' | \
    sed 's/\.class$//'
  ) | \
  grep -o 'major version: [4-9][0-9]' | \
  sed 's/major version: //' | \
  sort -u | \
  xargs -I{} sh -c 'echo "$(( {} - 44 ))"'
5
8
11
```

The `jansi` class files are Java 8 bytecode; the `picocli` ones Java 5; ours Java 11.

---

The classes in the [test class path](https://docs.gradle.org/current/userguide/java_plugin.html#sec:java_tasks) (`compileTestJava`) will use the configured toolchain version, i.e. Java 21.

Some test classes use text blocks (Java 17).

Java 17 is [EOL](https://whichjdk.com/#releases) and the test classes are not published, so it makes no sense to use the release 17 for `compileTestJava`.