### PR TITLE
Added an option to set a manual ADR number

### DIFF
--- a/src/main/java/org/doble/commands/CommandNew.java
+++ b/src/main/java/org/doble/commands/CommandNew.java
@@ -59,6 +59,11 @@ public class CommandNew implements Callable<Integer> {
 			+ " Multiple -s options can be given, so that the new ADR can supersede multiple existing ADRs")
 	ArrayList<Integer> supersedes = new ArrayList<Integer>();
 
+	@Option(names = {"-n", "-number" }, 
+			description = "The ADR number to use for the ADR to be created. The default is one greater than the "
+				+ "greatest existing ADR.")
+	Integer manualADRNumber;
+
 	@ParentCommand
 	CommandADR commandADR;
 
@@ -130,9 +135,11 @@ public class CommandNew implements Callable<Integer> {
 		// Set up the author's email
 		String authorEmail = properties.getProperty("authorEmail", "").trim();
 
+		Integer adrNumber = manualADRNumber != null ? manualADRNumber : highestIndex() + 1;
+
 		// Build the record
 		Record record = new Record.Builder(rootPath, docsPath, dateFormatter)
-				.id(highestIndex() + 1)
+				.id(adrNumber)
 				.name(adrTitle)
 				.date(LocalDate.now())
 				.author(env.author)


### PR DESCRIPTION
Adding a command line option to set the number of the ADR to be generated.

This comes up in one of my projects because we have multiple ADR contributors across multiple branches, so simply indexing the last number on a given branch is not guaranteed to give the next available ADR number.